### PR TITLE
fix: down the cmake minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_GENERATOR
     "Unix Makefiles"


### PR DESCRIPTION
to match the version use on the epitest-docker (3.27.2)